### PR TITLE
wayland: do not exit until ^C in wayland mode

### DIFF
--- a/src/redshift.c
+++ b/src/redshift.c
@@ -1244,11 +1244,12 @@ main(int argc, char *argv[])
 				exit(EXIT_FAILURE);
 			}
 
-			/* In Quartz (macOS) the gamma adjustments will
-			   automatically revert when the process exits.
+			/* In Quartz (macOS) and wayland, the gamma adjustments
+			   will automatically revert when the process exits.
 			   Therefore, we have to loop until CTRL-C is received.
 			   */
-			if (strcmp(options.method->name, "quartz") == 0) {
+			if (strcmp(options.method->name, "quartz") == 0 ||
+					strcmp(options.method->name, "wayland") == 0) {
 				fputs(_("Press ctrl-c to stop...\n"), stderr);
 				pause();
 			}
@@ -1273,10 +1274,11 @@ main(int argc, char *argv[])
 			exit(EXIT_FAILURE);
 		}
 
-		/* In Quartz (OSX) the gamma adjustments will automatically
-		   revert when the process exits. Therefore, we have to loop
-		   until CTRL-C is received. */
-		if (strcmp(options.method->name, "quartz") == 0) {
+		/* In Quartz (OSX) and wayland, the gamma adjustments will
+		   automatically revert when the process exits.
+		   Therefore, we have to loop until CTRL-C is received. */
+		if (strcmp(options.method->name, "quartz") == 0 ||
+				strcmp(options.method->name, "wayland") == 0) {
 			fputs(_("Press ctrl-c to stop...\n"), stderr);
 			pause();
 		}
@@ -1295,10 +1297,11 @@ main(int argc, char *argv[])
 			exit(EXIT_FAILURE);
 		}
 
-		/* In Quartz (OSX) the gamma adjustments will automatically
-		   revert when the process exits. Therefore, we have to loop
-		   until CTRL-C is received. */
-		if (strcmp(options.method->name, "quartz") == 0) {
+		/* In Quartz (OSX) and wayland, the gamma adjustments will
+		   automatically revert when the process exits.
+		   Therefore, we have to loop until CTRL-C is received. */
+		if (strcmp(options.method->name, "quartz") == 0 ||
+				strcmp(options.method->name, "wayland") == 0) {
 			fputs(_("Press ctrl-c to stop...\n"), stderr);
 			pause();
 		}


### PR DESCRIPTION
wlr-gamma-control behaves like Quartz and the gamma adjustments reset
when the process exits, so keep running until ctrl-c is pressed

At some point I'll want to implement a basic "read stdin for new temperatures" mode, but I'll submit that directly to the main repo if I ever do... This "wait until ^C" works but the screen flickers when I adjust gamma with my script that just pkill + restart new one :/
(and obviously cannot start new one before killing old one, because it says some other client already hogs the gamma ramp)